### PR TITLE
Skip IBC receiver decoding error

### DIFF
--- a/x/fiattokenfactory/ante.go
+++ b/x/fiattokenfactory/ante.go
@@ -202,7 +202,9 @@ func (ad IsBlacklistedDecorator) CheckMessages(ctx sdk.Context, msgs []sdk.Msg, 
 			if errors.Is(err, fiattokenfactorytypes.ErrUnauthorized) {
 				return sdkerrors.Wrapf(err, "an address (%s) is blacklisted and can not receive tokens", m.Receiver)
 			} else if err != nil {
-				return sdkerrors.Wrapf(err, "error decoding address (%s)", m.Receiver)
+				// Ignore the decoding error because the receiver address could be a non-cosmos address
+				// and the destination chain should be in charge of minting the token
+				continue
 			}
 		default:
 			continue


### PR DESCRIPTION
Hello again,

IBC transfers to non-CosmosSDK chain still failed because it assumed that the IBC receiver address is a CosmosSDK address.
The point of this PR is the same as https://github.com/noble-assets/noble/pull/301