### PR TITLE
chore: onboard stepsecurity and apply security best practice

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -21,15 +21,23 @@ on:
   push:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   e2e-tests:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@19bb51245e9c80abacb2e91cc42b33fa478b8639 # v4.2.1
         with:
           go-version: 1.21
 

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -27,11 +27,14 @@ permissions:
 jobs:
   e2e-tests:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+      - name: Harden the runner
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
-          egress-policy: audit
+          egress-policy: block
+          policy: global-allowed-endpoints-policy
 
       - name: Checkout Repository
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -25,11 +25,16 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@19bb51245e9c80abacb2e91cc42b33fa478b8639 # v4.2.1
         with:
           go-version: 1.21
 

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -24,11 +24,14 @@ on:
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+      - name: Harden the runner
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
-          egress-policy: audit
+          egress-policy: block
+          policy: global-allowed-endpoints-policy
 
       - name: Checkout Repository
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0


### PR DESCRIPTION
## Summary
This pull request improves the security and reliability of the GitHub Actions workflows for end-to-end and unit tests. The main changes include hardening the runners, specifying permissions more explicitly, and pinning action versions to specific commit SHAs for better reproducibility.

Security hardening:

* Added the `step-security/harden-runner` action to both `.github/workflows/e2e-tests.yaml` and `.github/workflows/unit-tests.yaml` to restrict network egress and enforce a global allowed endpoints policy. [[1]](diffhunk://#diff-deaabb10671a187e9d8bc2a25d16791aa368a5a6e3d970c3d42977712b6fd60fR24-R43) [[2]](diffhunk://#diff-6e608e02c595d53ab6b70822a2bf19abcfc6ddcc976c2f536ad5bfca20f0443fR27-R40)

Permissions improvements:

* Explicitly set `permissions` at the workflow and job levels, including `contents: read` and `id-token: write`, to follow the principle of least privilege. [[1]](diffhunk://#diff-deaabb10671a187e9d8bc2a25d16791aa368a5a6e3d970c3d42977712b6fd60fR24-R43) [[2]](diffhunk://#diff-6e608e02c595d53ab6b70822a2bf19abcfc6ddcc976c2f536ad5bfca20f0443fR27-R40)

Reliability and reproducibility:

* Updated `actions/checkout` and `actions/setup-go` to use pinned commit SHAs instead of version tags, ensuring consistent action versions across workflow runs. [[1]](diffhunk://#diff-deaabb10671a187e9d8bc2a25d16791aa368a5a6e3d970c3d42977712b6fd60fR24-R43) [[2]](diffhunk://#diff-6e608e02c595d53ab6b70822a2bf19abcfc6ddcc976c2f536ad5bfca20f0443fR27-R40)

## Testing

## Documentation

---

**Requested Reviewers:** @mention
