### PR TITLE
chore(ci): bump GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -26,10 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 1.21
 

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -26,10 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 1.21
 


### PR DESCRIPTION
## Summary

Bulk SHA-pin update of GitHub Actions to their latest Node-24-compatible release. Pre-emptive migration ahead of GitHub Actions runner Node 20 removal in Fall 2026.

## Actions bumped

- `actions/checkout@v3` → `df4cb1c0…` (v6.0.3)
- `actions/setup-go@v4` → `4a360112…` (v6.4.0)

## Verification

Every emitted SHA was verified via `gh api /repos/<owner>/<repo>/commits/<sha>` before commit.

## Background

Node 20 is being removed from GitHub Actions runners in Fall 2026 (see [GitHub changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). This PR pre-emptively bumps every pinned third-party action to its first Node-24-compatible release so the workflows keep running on the new runner default.